### PR TITLE
Fix incorrect max boost when enabling threads

### DIFF
--- a/main_view.html
+++ b/main_view.html
@@ -9,11 +9,15 @@
             function getVersion() {
                 return call_plugin_method("get_version", {});
             }
-            
+
+            function onViewReady() {
+                return call_plugin_method("on_ready", {});
+            }
+
             function setCPUs(value, smt) {
                 return call_plugin_method("set_cpus", {"count":value, "smt": smt});
             }
-            
+
             function getCPUs() {
                 return call_plugin_method("get_cpus", {});
             }
@@ -73,6 +77,8 @@
             // other logic
             
             async function onReady() {
+                await onViewReady();
+
                 let boostToggle = document.getElementById("boostToggle");
                 setToggleState(boostToggle, await getCPUBoost());
                 setToggleState(document.getElementById("smtToggle"), await getSMT());


### PR DESCRIPTION
When you set the max boost, disabled threads won't be updated.
As a result, they will have the old max boost when enabled.


Steps to reproduce:
1: disable 1 or more threads
2: set the max boost
3: enable 1 or more threads

The re-enabled threads will have the old max boost.



This patch works by storing the max boost, which will be applied after enabling threads.