### PR TITLE
Add Transparent Hugepages option

### DIFF
--- a/backend/src/api/memory.rs
+++ b/backend/src/api/memory.rs
@@ -1,0 +1,67 @@
+use std::sync::{mpsc::Sender, Arc, Mutex};
+use usdpl_back::core::serdes::Primitive;
+
+use crate::settings::{Memory, OnSet};
+use crate::utility::{unwrap_lock, unwrap_maybe_fatal};
+
+/// Generate get THP enabled web method
+pub fn get_transparent_hugepages_enabled(
+    settings: Arc<Mutex<Memory>>,
+) -> impl Fn(super::ApiParameterType) -> super::ApiParameterType {
+    move |_: super::ApiParameterType| {
+        let settings_lock = unwrap_lock(settings.lock(), "memory");
+        vec![settings_lock
+            .transparent_hugepages
+            .or_else(|| Memory::read_transparent_hugepages_enabled().ok())
+            .unwrap_or_default()
+            .to_string()
+            .into()]
+    }
+}
+
+/// Generate set THP enabled web method
+pub fn set_transparent_hugepages_enabled(
+    settings: Arc<Mutex<Memory>>,
+    saver: Sender<()>,
+) -> impl Fn(super::ApiParameterType) -> super::ApiParameterType {
+    let saver = Mutex::new(saver); // Sender is not Sync; this is required for safety
+    move |params_in: super::ApiParameterType| {
+        if let Some(Primitive::String(new_val)) = params_in.get(0) {
+            let mut settings_lock = unwrap_lock(settings.lock(), "memory");
+            settings_lock.transparent_hugepages = new_val.parse().ok();
+            unwrap_maybe_fatal(
+                unwrap_lock(saver.lock(), "save channel").send(()),
+                "Failed to send on save channel",
+            );
+            super::utility::map_empty_result(
+                settings_lock.on_set(),
+                settings_lock.transparent_hugepages.unwrap().to_string(),
+            )
+        } else {
+            vec!["set_transparent_hugepages_enabled missing parameter".into()]
+        }
+    }
+}
+
+/// Generate unset THP enabled web method
+pub fn unset_transparent_hugepages_enabled(
+    settings: Arc<Mutex<Memory>>,
+    saver: Sender<()>,
+) -> impl Fn(super::ApiParameterType) -> super::ApiParameterType {
+    let saver = Mutex::new(saver); // Sender is not Sync; this is required for safety
+    move |_: super::ApiParameterType| {
+        let mut settings_lock = unwrap_lock(settings.lock(), "memory");
+        settings_lock.transparent_hugepages = None;
+        unwrap_maybe_fatal(
+            unwrap_lock(saver.lock(), "save channel").send(()),
+            "Failed to send on save channel",
+        );
+        super::utility::map_empty_result(
+            settings_lock.on_set(),
+            Memory::read_transparent_hugepages_enabled()
+                .ok()
+                .unwrap_or_default()
+                .to_string(),
+        )
+    }
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod battery;
 pub mod cpu;
 pub mod general;
 pub mod gpu;
+pub mod memory;
 mod utility;
 
 pub(super) type ApiParameterType = Vec<usdpl_back::core::serdes::Primitive>;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -144,6 +144,19 @@ fn main() -> Result<(), ()> {
             "GPU_get_slow_memory",
             api::gpu::get_slow_memory(loaded_settings.gpu.clone())
         )
+        // memory API functions
+        .register(
+            "MEMORY_get_transparent_hugepages_enabled",
+            api::memory::get_transparent_hugepages_enabled(loaded_settings.memory.clone()),
+        )
+        .register(
+            "MEMORY_set_transparent_hugepages_enabled",
+            api::memory::set_transparent_hugepages_enabled(loaded_settings.memory.clone(), save_sender.clone()),
+        )
+        .register(
+            "MEMORY_unset_transparent_hugepages_enabled",
+            api::memory::unset_transparent_hugepages_enabled(loaded_settings.memory.clone(), save_sender.clone()),
+        )
         // general API functions
         .register(
             "GENERAL_set_persistent",

--- a/backend/src/persist/general.rs
+++ b/backend/src/persist/general.rs
@@ -3,7 +3,7 @@ use std::default::Default;
 use serde::{Deserialize, Serialize};
 
 use super::JsonError;
-use super::{BatteryJson, CpuJson, GpuJson};
+use super::{BatteryJson, CpuJson, GpuJson, MemoryJson};
 
 #[derive(Serialize, Deserialize)]
 pub struct SettingsJson {
@@ -13,6 +13,7 @@ pub struct SettingsJson {
     pub cpus: Vec<CpuJson>,
     pub gpu: GpuJson,
     pub battery: BatteryJson,
+    pub memory: MemoryJson,
 }
 
 impl Default for SettingsJson {
@@ -24,6 +25,7 @@ impl Default for SettingsJson {
             cpus: Vec::with_capacity(8),
             gpu: GpuJson::default(),
             battery: BatteryJson::default(),
+            memory: MemoryJson::default(),
         }
     }
 }

--- a/backend/src/persist/memory.rs
+++ b/backend/src/persist/memory.rs
@@ -1,0 +1,16 @@
+use std::default::Default;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct MemoryJson {
+    pub transparent_hugepages: Option<String>,
+}
+
+impl Default for MemoryJson {
+    fn default() -> Self {
+        Self {
+            transparent_hugepages: None,
+        }
+    }
+}

--- a/backend/src/persist/mod.rs
+++ b/backend/src/persist/mod.rs
@@ -3,10 +3,12 @@ mod cpu;
 mod error;
 mod general;
 mod gpu;
+mod memory;
 
 pub use battery::BatteryJson;
 pub use cpu::CpuJson;
 pub use general::{MinMaxJson, SettingsJson};
 pub use gpu::GpuJson;
+pub use memory::MemoryJson;
 
 pub use error::JsonError;

--- a/backend/src/settings/memory.rs
+++ b/backend/src/settings/memory.rs
@@ -1,0 +1,165 @@
+use std::convert::Into;
+use std::fmt::{Display};
+use std::str::FromStr;
+
+use super::{OnResume, OnSet, SettingError};
+use crate::persist::MemoryJson;
+
+#[derive(Debug, Clone)]
+pub struct Memory {
+    pub transparent_hugepages: Option<TransparentHugepages>,
+    state: crate::state::Memory,
+}
+
+const MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH: &str = "/sys/kernel/mm/transparent_hugepage/enabled";
+
+impl Memory {
+    #[inline]
+    pub fn from_json(other: MemoryJson, version: u64) -> Self {
+        match version {
+            0 => Self {
+                transparent_hugepages: other.transparent_hugepages.and_then(|v| TransparentHugepages::from_str(&v).ok()),
+                state: crate::state::Memory::default(),
+            },
+            _ => Self {
+                transparent_hugepages: other.transparent_hugepages.and_then(|v| TransparentHugepages::from_str(&v).ok()),
+                state: crate::state::Memory::default(),
+            },
+        }
+    }
+
+    fn set_all(&mut self) -> Result<(), SettingError> {
+        if let Some(thp) = self.transparent_hugepages {
+            self.state.transparent_hugepages_set = true;
+            usdpl_back::api::files::write_single(MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH, thp.to_string()).map_err(
+                |e| SettingError {
+                    msg: format!("Failed to write to `{}`: {}", MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH, e),
+                    setting: super::SettingVariant::Memory,
+                },
+            )
+        } else if self.state.transparent_hugepages_set {
+            self.state.transparent_hugepages_set = false;
+            usdpl_back::api::files::write_single(MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH, TransparentHugepages::default().to_string()).map_err(
+                |e| SettingError {
+                    msg: format!("Failed to write to `{}`: {}", MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH, e),
+                    setting: super::SettingVariant::Memory,
+                },
+            )
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn system_default() -> Self {
+        Self {
+            transparent_hugepages: Some(usdpl_back::api::files::read_single(MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH).unwrap_or_default()),
+            state: crate::state::Memory::default(),
+        }
+    }
+
+    pub fn read_transparent_hugepages_enabled() -> Result<TransparentHugepages, SettingError> {
+        match usdpl_back::api::files::read_single::<_, TransparentHugepages, _>(MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH) {
+            Ok(val) => Ok(val),
+            Err((Some(e), None)) => Err(SettingError {
+                msg: format!("Failed to read from `{}`: {}", MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH, e),
+                setting: super::SettingVariant::Battery,
+            }),
+            Err((None, Some(e))) => Err(SettingError {
+                msg: format!("Failed to read from `{}`: {}", MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH, e),
+                setting: super::SettingVariant::Battery,
+            }),
+            Err(_) => panic!(
+                "Invalid error while reading from `{}`",
+                MM_TRANSPARENT_HUGEPAGES_ENABLED_PATH
+            ),
+        }
+    }
+}
+
+impl Into<MemoryJson> for Memory {
+    #[inline]
+    fn into(self) -> MemoryJson {
+        MemoryJson {
+            transparent_hugepages: self.transparent_hugepages.map(|v| v.to_string()),
+        }
+    }
+}
+
+impl OnSet for Memory {
+    fn on_set(&mut self) -> Result<(), SettingError> {
+        self.set_all()
+    }
+}
+
+impl OnResume for Memory {
+    fn on_resume(&self) -> Result<(), SettingError> {
+        let mut copy = self.clone();
+        copy.set_all()
+    }
+}
+
+/// Error for FromStr impl of TransparentHugepages.
+pub enum TransparentHugepagesParseError {
+    UnknownOption(String),
+}
+
+impl Display for TransparentHugepagesParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownOption(s) => write!(f, "unknown transparent hugepages option: {}", s),
+        }
+    }
+}
+
+/// Options for transparent hugepages.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum TransparentHugepages {
+    Always,
+    MAdvise,
+    Never, // Do not use - https://serverfault.com/a/896131
+}
+
+impl Default for TransparentHugepages {
+    fn default() -> Self {
+        TransparentHugepages::MAdvise
+    }
+}
+
+impl FromStr for TransparentHugepages {
+    type Err = TransparentHugepagesParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // If the format is from the sysfs file, try to extract it out.
+        // Example: always [madvise] never
+        let has_brackets = s.contains("[") && s.contains("]");
+        if has_brackets {
+            let bracketed: String = s.chars()
+                .skip_while(|c| *c != '[')
+                .skip(1)
+                .take_while(|c| *c != ']')
+                .collect();
+
+            return TransparentHugepages::from_str(&bracketed)
+        }
+
+        // Selected an enum variant from the string's value.
+        use TransparentHugepages::*;
+        match s {
+            "always" => Ok(Always),
+            "madvise" => Ok(MAdvise),
+            "never" => Ok(Never),
+            _ => Err(TransparentHugepagesParseError::UnknownOption(s.to_owned())),
+        }
+    }
+}
+
+impl ToString for TransparentHugepages {
+    fn to_string(&self) -> String {
+        use TransparentHugepages::*;
+        match self {
+            Always => "always",
+            MAdvise => "madvise",
+            Never => "never",
+        }.to_owned()
+    }
+}

--- a/backend/src/settings/mod.rs
+++ b/backend/src/settings/mod.rs
@@ -3,6 +3,7 @@ mod cpu;
 mod error;
 mod general;
 mod gpu;
+mod memory;
 mod min_max;
 mod traits;
 
@@ -10,7 +11,9 @@ pub use battery::Battery;
 pub use cpu::Cpu;
 pub use general::{SettingVariant, Settings, General};
 pub use gpu::Gpu;
+pub use memory::Memory;
 pub use min_max::MinMax;
+pub use memory::{TransparentHugepages, TransparentHugepagesParseError};
 
 pub use error::SettingError;
 pub use traits::{OnResume, OnSet, SettingsRange};

--- a/backend/src/state/memory.rs
+++ b/backend/src/state/memory.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, Clone)]
+pub struct Memory {
+    pub transparent_hugepages_set: bool,
+}
+
+impl std::default::Default for Memory {
+    fn default() -> Self {
+        Self {
+            transparent_hugepages_set: false,
+        }
+    }
+}

--- a/backend/src/state/mod.rs
+++ b/backend/src/state/mod.rs
@@ -2,10 +2,12 @@ mod battery;
 mod cpu;
 mod error;
 mod gpu;
+mod memory;
 mod traits;
 
 pub use battery::Battery;
 pub use cpu::Cpu;
 pub use error::StateError;
 pub use gpu::Gpu;
+pub use memory::Memory;
 pub use traits::OnPoll;

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -132,6 +132,20 @@ export async function getGpuSlowMemory(): Promise<boolean> {
     return (await call_backend("GPU_get_slow_memory", []))[0];
 }
 
+// Memory
+
+export async function getMemoryTransparentHugepagesEnabled(): Promise<'always' | 'madvise' | 'never'> {
+    return (await call_backend("MEMORY_get_transparent_hugepages_enabled", []))[0];
+}
+
+export async function setMemoryTransparentHugepagesEnabled(state: 'always' | 'madvise' | 'never'): Promise<'always' | 'madvise' | 'never'> {
+    return (await call_backend("MEMORY_set_transparent_hugepages_enabled", [state]))[0];
+}
+
+export async function unsetMemoryTransparentHugepagesEnabled(): Promise<'always' | 'madvise' | 'never'> {
+    return (await call_backend("MEMORY_unset_transparent_hugepages_enabled", []))[0];
+}
+
 // general
 
 export async function setGeneralPersistent(val: boolean): Promise<boolean> {


### PR DESCRIPTION
This commit adds the ability for PowerTools to change the [kernel transparent hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html) setting.

I gave the backend the ability to change between `never`, `madvise`, and `always`, but only gave the frontend the option to toggle between `always` and `madvise`. While this might seem like an odd choice, the kernel docs [mention](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#global-thp-controls) that `never` is "mostly used for debugging purposes". With `madvise` as the "off" option, it requires processes to explicitly opt in to THP support via syscalls. Presumably these processes would know how to use it properly, and would be negatively affected by turning THP off entirely.

**Known Issues:**

- [Changing the THP enabled setting only affects new processes.](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#need-of-application-restart)  
  Depending on how the game launches and the timing of PowerTool's persistence setting, any changes to the THP setting may not take affect in time.

**Future Considerations:**

- With a new memory section, it might be nice to move the "Downclock Memory" option to there instead of under the GPU section.