### PR TITLE
Fix DeckyFront End Errorr by bumping DFL to 3.20.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "decky-frontend-lib": "~3.20.5",
+    "decky-frontend-lib": "~3.20.7",
     "react-icons": "^4.8.0",
     "usdpl-front": "file:src/usdpl_front"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   decky-frontend-lib:
-    specifier: ~3.20.5
-    version: 3.20.5
+    specifier: ~3.20.7
+    version: 3.20.7
   react-icons:
     specifier: ^4.8.0
     version: 4.8.0(react@18.2.0)
@@ -433,8 +433,8 @@ packages:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
     dev: true
 
-  /decky-frontend-lib@3.20.5:
-    resolution: {integrity: sha512-aXllFYhWovoiyBHNzH8PW9EYgXotY9ysuU9icFNgrOWFotyJV+2KGLnfYEyBlDNiexKvXKVRKPw1gRFX2hP4AQ==}
+  /decky-frontend-lib@3.20.7:
+    resolution: {integrity: sha512-Zwwbo50cqpTbCfSCZaqITgTRvWs7pK9KO1A+Oo2sCC/DqOfyUtEH5niNPid4Qxu+yh4lsbEjTurJk1nCfd+nZw==}
     dev: false
 
   /deepmerge@4.3.1:


### PR DESCRIPTION
Fix for [Decky Front End Error #100](https://github.com/NGnius/PowerTools/issues/100) by bumping DFL to 3.20.7